### PR TITLE
Verification

### DIFF
--- a/routes/link.js
+++ b/routes/link.js
@@ -310,7 +310,7 @@ module.exports = [
       handler: async (request, h) => {
         try {
           const { companyId, participationDays, advertisementKind, activities, companyEmail } = request.payload
-          const { edition, token, isCompanyValid, company, member } = request.pre
+          const { edition, isCompanyValid, token, company, member } = request.pre
 
           if (isCompanyValid === false) {
             return Boom.badData('CompanyId does not exist')
@@ -320,14 +320,21 @@ module.exports = [
             return Boom.badData('Invalid email')
           }
 
+          if (member.mails.main === undefined) {
+            return Boom.badData('The member (SINFO Organizer) doesn\'t have his/her main email setup. This email should be something like john.doe@sinfo.org')
+          }
+
           let link = await request.server.methods.link.create(
             companyId, company.name, edition,
             member.mails.main, token, participationDays,
             activities, advertisementKind, companyEmail
           )
 
+          console.log(link);
           return link === null ? Boom.badData('No link associated') : link.toJSON()
         } catch (err) {
+          console.log("got to the error")
+          console.log(err)
           logger.error({ info: request.info, error: err })
           return Boom.boomify(err)
         }

--- a/routes/link.js
+++ b/routes/link.js
@@ -330,11 +330,8 @@ module.exports = [
             activities, advertisementKind, companyEmail
           )
 
-          console.log(link);
           return link === null ? Boom.badData('No link associated') : link.toJSON()
         } catch (err) {
-          console.log("got to the error")
-          console.log(err)
           logger.error({ info: request.info, error: err })
           return Boom.boomify(err)
         }


### PR DESCRIPTION
If the user tried to create a link without a mail listed under `main` in the database, corlief would fail with a 500 (silently).

Now, it fails with 422 and the cause is listed in the error.