### PR TITLE
fix: proper handle jwt.verify

### DIFF
--- a/auth/company.js
+++ b/auth/company.js
@@ -1,20 +1,16 @@
 module.exports = server => {
   server.auth.strategy('company', 'bearer-access-token', {
-    validate: async (request, token, h) => {
+    validate: async (request, token) => {
       try {
-        let link = await request.server.methods.link.findByToken(token)
+        const link = await request.server.methods.link.findByToken(token)
+        if (!link || !link.valid) return { isValid: false }
 
-        if (link === null || link.valid === false) {
-          return { isValid: false, credentials: token, artifacts: token }
-        }
+        const decoded = await request.server.methods.jwt.verify(token)
+        if (!decoded) return { isValid: false }
 
-        let decoded = await request.server.methods.jwt.verify(token)
-
-        return decoded
-          ? { isValid: true, credentials: decoded, artifacts: token }
-          : { isValid: false, credentials: token, artifacts: token }
+        return { isValid: true, credentials: decoded, artifacts: token }
       } catch (err) {
-        return { isValid: false, credentials: token, artifacts: token }
+        return { isValid: false }
       }
     }
   })

--- a/auth/sinfo.js
+++ b/auth/sinfo.js
@@ -42,8 +42,10 @@ function authenticate(user) {
 
 module.exports = server => {
   server.auth.strategy('sinfo', 'bearer-access-token', {
-    validate: async (request, token, h) => {
-      return jwt.verify(token)
+    validate: async (request, token) => {
+      const decoded = await jwt.verify(token)
+      if (!decoded) throw Boom.unauthorized('Invalid token')
+      return { isValid: true, credentials: decoded, artifacts: token }
     }
   })
 

--- a/plugins/jwt.js
+++ b/plugins/jwt.js
@@ -28,12 +28,9 @@ async function generate (data, options) {
 
 async function verify (token) {
   try {
-    const decoded = jwt.verify(token, publicKey)
-    return decoded
-          ? { isValid: true, credentials: decoded, artifacts: token }
-          : { isValid: false, credentials: token, artifacts: token }
+    return jwt.verify(token, publicKey)
   } catch (err) {
-    throw Boom.unauthorized(err)
+    return null
   }
 }
 

--- a/test/link.js
+++ b/test/link.js
@@ -592,8 +592,8 @@ describe('link', async function () {
       expect(response.statusCode).to.eql(200)
 
       // check if response token is correct (exp is in seconds)
-      const token = await server.methods.jwt.verify(response.result.token)
-      expect(token.exp).to.eql(Math.floor(expirationDate / 1000))
+      const decoded = await server.methods.jwt.verify(response.result.token)
+      expect(decoded.exp).to.eql(Math.floor(expirationDate / 1000))
 
       // apart from the token link should remain the same (but now valid)
       Object.keys(response.result).forEach(key => {


### PR DESCRIPTION
From the documentation of `jsonwebtoken` the function `verify` has the following behavior:

>jwt.verify(token, secretOrPublicKey, [options, callback])
> 
> (Asynchronous) If a callback is supplied, function acts asynchronously. The callback is called with the decoded payload if  the signature is valid and optional expiration, audience, or issuer are valid. If not, it will be called with the error.
>
> (Synchronous) If a callback is not supplied, function acts synchronously. Returns the payload decoded if the signature is valid and optional expiration, audience, or issuer are valid. If not, it will throw the error.

So we need to catch the exception and return false/null if the token is invalid (e.g. expired)